### PR TITLE
Update for SMAPI 2.0

### DIFF
--- a/DynamicChecklist/DynamicChecklist.csproj
+++ b/DynamicChecklist/DynamicChecklist.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>DynamicChecklist</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <DeployModFolderName>$(MSBuildProjectName)</DeployModFolderName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,12 +46,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -91,32 +86,47 @@
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Resources\arrowRight.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\crab.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\empty.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\hand.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\heart.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\milkPail.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\plus.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\shears.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\Sign.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\speechBubble.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resources\wateringCan.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <Target Name="AfterBuild">
-    <PropertyGroup>
-      <ModPath>$(GamePath)\Mods\$(TargetName)</ModPath>
-    </PropertyGroup>
-    <ItemGroup>
-      <_CopyItems Include="$(ProjectDir)\Resources\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
-    <Copy SourceFiles="@(_CopyItems)" DestinationFolder="$(ModPath)\Resources" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.7.1\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/DynamicChecklist/MainClass.cs
+++ b/DynamicChecklist/MainClass.cs
@@ -31,11 +31,12 @@
             ControlEvents.KeyPressed += this.ReceiveKeyPress;
             SaveEvents.AfterLoad += this.GameLoadedEvent;
             SaveEvents.AfterSave += this.OnAfterSave;
-            GameEvents.GameLoaded += this.OnGameLoaded;
-            TimeEvents.DayOfMonthChanged += this.OnDayOfMonthChanged;
+            TimeEvents.AfterDayStarted += this.AfterDayStarted;
             GraphicsEvents.OnPreRenderHudEvent += this.DrawTick;
             GameEvents.OneSecondTick += this.UpdatePaths;
             LocationEvents.CurrentLocationChanged += this.UpdatePaths;
+
+            OverlayTextures.LoadTextures(this.helper.DirectoryPath);
             try
             {
                 this.openMenuKey = (Keys)Enum.Parse(typeof(Keys), this.config.OpenMenuKey);
@@ -107,7 +108,7 @@
             }
         }
 
-        private void OnDayOfMonthChanged(object sender, EventArgs e)
+        private void AfterDayStarted(object sender, EventArgs e)
         {
             foreach (ObjectList ol in this.objectLists)
             {
@@ -136,11 +137,6 @@
                     }
                 }
             }
-        }
-
-        private void OnGameLoaded(object sender, EventArgs e)
-        {
-            OverlayTextures.LoadTextures(this.helper.DirectoryPath);
         }
 
         private void InitializeObjectLists()

--- a/DynamicChecklist/Properties/AssemblyInfo.cs
+++ b/DynamicChecklist/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]

--- a/DynamicChecklist/manifest.json
+++ b/DynamicChecklist/manifest.json
@@ -1,13 +1,14 @@
 {
-   "Name": "DynamicChecklist",
-   "Author": "gunnargolf",
-   "Version": {
-      "MajorVersion": 1,
-      "MinorVersion": 0,
-      "PatchVersion": 0,
-      "Build": ""
-   },
-   "Description": "Creates a dynamic checklist of tasks for the day",
-   "UniqueID": "gunnargolf.DynamicChecklist",
-   "EntryDll": "DynamicChecklist.dll"
+  "Name": "DynamicChecklist",
+  "Author": "gunnargolf",
+  "Version": {
+    "MajorVersion": 1,
+    "MinorVersion": 0,
+    "PatchVersion": 0,
+    "Build": null
+  },
+  "Description": "Creates a dynamic checklist of tasks for the day",
+  "UniqueID": "gunnargolf.DynamicChecklist",
+  "EntryDll": "DynamicChecklist.dll",
+  "UpdateKeys": [ "Nexus:1145" ]
 }

--- a/DynamicChecklist/manifest.json
+++ b/DynamicChecklist/manifest.json
@@ -4,7 +4,7 @@
   "Version": {
     "MajorVersion": 1,
     "MinorVersion": 0,
-    "PatchVersion": 0,
+    "PatchVersion": 1,
     "Build": null
   },
   "Description": "Creates a dynamic checklist of tasks for the day",

--- a/DynamicChecklist/packages.config
+++ b/DynamicChecklist/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.5.0" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.7.1" targetFramework="net45" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
This pull request...

* Fixes compatibility with SMAPI 2.0 (without breaking compatibility with earlier versions).
* Updates the [mod build package](https://github.com/Pathoschild/Stardew.ModBuildConfig) to the latest version.  
    _This adds support for deploying into the mod folder automatically._
* Enables update checks in SMAPI 2.0.
* Bumps the versions for release.

If the changes look fine, can you release [DynamicChecklist 1.0.1.zip](https://github.com/gunnargolf/DynamicChecklist/files/1357805/DynamicChecklist.1.0.1.zip) to the [Nexus mod page](https://www.nexusmods.com/stardewvalley/mods/1145)?