### PR TITLE
Upgrade to SMAPI 3

### DIFF
--- a/DynamicChecklist.sln
+++ b/DynamicChecklist.sln
@@ -1,22 +1,31 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29709.97
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamicChecklist", "DynamicChecklist\DynamicChecklist.csproj", "{62AEF160-7012-4676-9867-61EBF0DB2415}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{62AEF160-7012-4676-9867-61EBF0DB2415}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{62AEF160-7012-4676-9867-61EBF0DB2415}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62AEF160-7012-4676-9867-61EBF0DB2415}.Debug|x86.ActiveCfg = Debug|x86
+		{62AEF160-7012-4676-9867-61EBF0DB2415}.Debug|x86.Build.0 = Debug|x86
 		{62AEF160-7012-4676-9867-61EBF0DB2415}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{62AEF160-7012-4676-9867-61EBF0DB2415}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62AEF160-7012-4676-9867-61EBF0DB2415}.Release|x86.ActiveCfg = Release|x86
+		{62AEF160-7012-4676-9867-61EBF0DB2415}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {234F94E8-B8A3-4A79-BF57-9914C77614BB}
 	EndGlobalSection
 EndGlobal

--- a/DynamicChecklist/DynamicChecklist.csproj
+++ b/DynamicChecklist/DynamicChecklist.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>DynamicChecklist.ruleset</CodeAnalysisRuleSet>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -32,6 +33,27 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>DynamicChecklist.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>DynamicChecklist.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>DynamicChecklist.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
@@ -123,16 +145,17 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\analyzers\dotnet\cs\SMAPI.ModBuildConfig.Analyzer.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.1.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/DynamicChecklist/Graph/Graphs/CompleteGraph.cs
+++ b/DynamicChecklist/Graph/Graphs/CompleteGraph.cs
@@ -14,17 +14,17 @@
 
     public class CompleteGraph : StardewGraph
     {
-        private List<GameLocation> gameLocations;
+        private IList<GameLocation> gameLocations;
         private DijkstraShortestPathAlgorithm<StardewVertex, StardewEdge> dijkstra;
         private VertexDistanceRecorderObserver<StardewVertex, StardewEdge> distObserver;
         private VertexPredecessorRecorderObserver<StardewVertex, StardewEdge> predecessorObserver;
 
-        public CompleteGraph(List<GameLocation> gameLocations)
+        public CompleteGraph(IList<GameLocation> gameLocations)
         {
             this.gameLocations = gameLocations;
         }
 
-        public List<PartialGraph> PartialGraphs { get; private set; } = new List<PartialGraph>();
+        public IList<PartialGraph> PartialGraphs { get; private set; } = new List<PartialGraph>();
 
         public void Populate()
         {
@@ -38,10 +38,10 @@
             var farmBuildings = Game1.getFarm().buildings;
             foreach (Building building in farmBuildings)
             {
-                if (building.indoors != null && building.indoors.GetType() == typeof(AnimalHouse))
+                var indoors = building.indoors.Value;
+                if (indoors != null && indoors is AnimalHouse)
                 {
-                    var animalHouse = (AnimalHouse)building.indoors;
-                    var partialGraph = new PartialGraph(animalHouse);
+                    var partialGraph = new PartialGraph((AnimalHouse)indoors);
                     partialGraph.Populate();
                     this.PartialGraphs.Add(partialGraph);
                 }

--- a/DynamicChecklist/Graph/Graphs/PartialGraph.cs
+++ b/DynamicChecklist/Graph/Graphs/PartialGraph.cs
@@ -39,12 +39,13 @@
 
                 foreach (Building building in farmBuildings)
                 {
-                    if (building.indoors != null && building.indoors.GetType() == typeof(AnimalHouse))
+                    var indoors = building.indoors.Value;
+                    if (indoors != null && indoors is AnimalHouse)
                     {
-                        var doorLoc = new Vector2(building.tileX + building.humanDoor.X, building.tileY + building.humanDoor.Y);
+                        var doorLoc = new Vector2(building.tileX.Value + building.humanDoor.X, building.tileY.Value + building.humanDoor.Y);
 
                         // Target location does not matter since an animal house is always at the end of the path
-                        var vertexNew = new WarpVertex(this.Location, doorLoc, building.indoors, new Vector2(0, 0));
+                        var vertexNew = new WarpVertex(this.Location, doorLoc, indoors, new Vector2(0, 0));
                         this.AddVertex(vertexNew);
                     }
                 }

--- a/DynamicChecklist/ObjectLists/AnimalList.cs
+++ b/DynamicChecklist/ObjectLists/AnimalList.cs
@@ -86,9 +86,10 @@
 
             foreach (Building building in farmBuildings)
             {
-                if (building.indoors != null && building.indoors.GetType() == typeof(AnimalHouse))
+                var indoors = building.indoors.Value;
+                if (indoors != null && indoors is AnimalHouse)
                 {
-                    var animalHouse = (AnimalHouse)building.indoors;
+                    var animalHouse = (AnimalHouse)indoors;
                     foreach (FarmAnimal animal in animalHouse.animals.Values.ToList())
                     {
                         StardewObjectInfo soi = this.CreateSOI(animal, animalHouse, this.action);
@@ -108,13 +109,13 @@
             switch (action)
             {
                 case Action.Pet:
-                    soi.NeedAction = !animal.wasPet;
+                    soi.NeedAction = !animal.wasPet.Value;
                     break;
                 case Action.Milk:
-                    soi.NeedAction = animal.currentProduce > 0 && animal.toolUsedForHarvest == "Milk Pail";
+                    soi.NeedAction = animal.currentProduce.Value > 0 && animal.toolUsedForHarvest.Value == "Milk Pail";
                     break;
                 case Action.Shear:
-                    soi.NeedAction = animal.currentProduce > 0 && animal.toolUsedForHarvest == "Shears";
+                    soi.NeedAction = animal.currentProduce.Value > 0 && animal.toolUsedForHarvest.Value == "Shears";
                     break;
                 default:
                     throw new NotImplementedException();

--- a/DynamicChecklist/ObjectLists/CrabPotList.cs
+++ b/DynamicChecklist/ObjectLists/CrabPotList.cs
@@ -51,8 +51,7 @@
         private void UpdateObjectInfoList(GameLocation loc)
         {
             this.ObjectInfoList.RemoveAll(soi => soi.Location == loc);
-
-            foreach (KeyValuePair<Vector2, StardewValley.Object> o in loc.Objects)
+            foreach (KeyValuePair<Vector2, StardewValley.Object> o in loc.Objects.Pairs)
             {
                 if (o.Value is CrabPot)
                 {
@@ -60,13 +59,13 @@
                     var soi = new StardewObjectInfo();
                     soi.Coordinate = o.Key * Game1.tileSize + new Vector2(Game1.tileSize / 2, Game1.tileSize / 2);
                     soi.Location = loc;
-                    if (currentCrabPot.readyForHarvest)
+                    if (currentCrabPot.readyForHarvest.Value)
                     {
                         soi.NeedAction = true;
                     }
 
                     // if player is luremaster, crab pots dont need bait
-                    if (currentCrabPot.bait == null && !Game1.player.professions.Contains(11))
+                    if (currentCrabPot.bait.Value == null && !Game1.player.professions.Contains(11))
                     {
                         soi.NeedAction = true;
                     }

--- a/DynamicChecklist/ObjectLists/CropList.cs
+++ b/DynamicChecklist/ObjectLists/CropList.cs
@@ -76,7 +76,7 @@
 
         private void UpdateObjectInfoList(GameLocation loc)
         {
-            foreach (KeyValuePair<Vector2, TerrainFeature> entry in loc.terrainFeatures)
+            foreach (KeyValuePair<Vector2, TerrainFeature> entry in loc.terrainFeatures.Pairs)
             {
                 var terrainFeature = entry.Value;
                 if (terrainFeature is HoeDirt)
@@ -97,8 +97,8 @@
             switch (action)
             {
                 case Action.Water:
-                    var isWatered = hoeDirt.state == HoeDirt.watered;
-                    soi.NeedAction = hoeDirt.needsWatering() && !isWatered && !hoeDirt.crop.dead;
+                    var isWatered = hoeDirt.state.Value == HoeDirt.watered;
+                    soi.NeedAction = hoeDirt.needsWatering() && !isWatered && !hoeDirt.crop.dead.Value;
                     break;
                 case Action.Harvest:
                     soi.NeedAction = hoeDirt.readyForHarvest();

--- a/DynamicChecklist/ObjectLists/EggList.cs
+++ b/DynamicChecklist/ObjectLists/EggList.cs
@@ -47,10 +47,11 @@
             var farmBuildings = Game1.getFarm().buildings;
             foreach (Building building in farmBuildings)
             {
-                if (building.indoors != null && building.indoors.GetType() == typeof(AnimalHouse))
+                var indoors = building.indoors.Value;
+                if (indoors != null && indoors is AnimalHouse)
                 {
-                    var animalHouse = (AnimalHouse)building.indoors;
-                    foreach (KeyValuePair<Vector2, StardewValley.Object> obj in animalHouse.Objects)
+                    var animalHouse = (AnimalHouse)indoors;
+                    foreach (KeyValuePair<Vector2, StardewValley.Object> obj in animalHouse.Objects.Pairs)
                     {
                         if (obj.Value.IsSpawnedObject)
                         {

--- a/DynamicChecklist/ObjectLists/HayList.cs
+++ b/DynamicChecklist/ObjectLists/HayList.cs
@@ -45,9 +45,10 @@
         {
             foreach (Building b in Game1.getFarm().buildings)
             {
-                if (b.indoors is AnimalHouse)
+                var indoors = b.indoors.Value;
+                if (indoors != null && indoors is AnimalHouse)
                 {
-                    this.UpdateObjectInfoList((AnimalHouse)b.indoors);
+                    this.UpdateObjectInfoList((AnimalHouse)indoors);
                 }
             }
 
@@ -57,7 +58,7 @@
         private void UpdateObjectInfoList(AnimalHouse animalHouse)
         {
             this.ObjectInfoList.RemoveAll(soi => soi.Location == animalHouse);
-            foreach (KeyValuePair<Vector2, StardewValley.Object> o in animalHouse.Objects)
+            foreach (KeyValuePair<Vector2, StardewValley.Object> o in animalHouse.Objects.Pairs)
             {
                 if (o.Value.Name.Equals("Hay"))
                 {

--- a/DynamicChecklist/ObjectLists/ObjectList.cs
+++ b/DynamicChecklist/ObjectLists/ObjectList.cs
@@ -11,7 +11,6 @@
 
     public abstract class ObjectList
     {
-        private Texture2D arrow;
         private ShortestPath path;
         private ModConfig config;
         private bool overlayActive;

--- a/DynamicChecklist/OpenChecklistButton.cs
+++ b/DynamicChecklist/OpenChecklistButton.cs
@@ -20,15 +20,14 @@
         private Func<int> countRemainingTasks;
         private ModConfig config;
 
-        public OpenChecklistButton(Action openChecklist, Func<int> countRemainingTasks, ModConfig config)
+        public OpenChecklistButton(Action openChecklist, Func<int> countRemainingTasks, ModConfig config, IModEvents events)
             : base(0, 0, OverlayTextures.Sign.Width * Game1.pixelZoom, OverlayTextures.Sign.Height * Game1.pixelZoom, false)
         {
             this.config = config;
             this.countRemainingTasks = countRemainingTasks;
             this.texture = OverlayTextures.Sign;
             this.openChecklist = openChecklist;
-
-            MenuEvents.MenuClosed += this.OnMenuClosed;
+            events.Display.MenuChanged += this.OnMenuClosed;
             this.UpdateButtonPosition(config.OpenChecklistButtonLocation);
         }
 
@@ -65,9 +64,9 @@
             base.draw(b);
         }
 
-        private void OnMenuClosed(object sender, EventArgsClickableMenuClosed e)
+        private void OnMenuClosed(object sender, MenuChangedEventArgs e)
         {
-            if (e.PriorMenu is ChecklistMenu)
+            if (e.OldMenu is ChecklistMenu)
             {
                 this.UpdateButtonPosition(this.config.OpenChecklistButtonLocation);
             }

--- a/DynamicChecklist/manifest.json
+++ b/DynamicChecklist/manifest.json
@@ -3,9 +3,9 @@
   "Author": "gunnargolf",
   "Version": {
     "MajorVersion": 1,
-    "MinorVersion": 0,
-    "PatchVersion": 1,
-    "Build": null
+    "MinorVersion": 1,
+    "PatchVersion": 0,
+    "Build": "stash1"
   },
   "Description": "Creates a dynamic checklist of tasks for the day",
   "UniqueID": "gunnargolf.DynamicChecklist",

--- a/DynamicChecklist/packages.config
+++ b/DynamicChecklist/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net45" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="3.1.0" targetFramework="net45" />
   <package id="QuickGraph" version="3.6.61119.7" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Upgrades DynamicChecklist to use SMAPI 3.1.0 (SDV 1.4.x)

Supersedes #7  

Summary of changes:
* Specific `List` had to get changed to type `IList` all over the place
* Many "net" objects needed to have either `.Pairs` or `.Value` added to compile again or satisfy the SMAPI checker
* `GetType()` dropped in favor of `is` operator
* Event hooks updated to the new names that got introduced in SMAPI 3
* No need for `.helper` since `Mod` already has a `.Helper` property
* Removed some unused fields (e.g., `arrow`) that were also generating warnings

Thanks for your consideration, and of course, for your awesome mod!