### PR TITLE
add missing IClickableMenu (Stardew 1.5.4)

### DIFF
--- a/DynamicChecklist/DynamicSelectableCheckbox.cs
+++ b/DynamicChecklist/DynamicSelectableCheckbox.cs
@@ -26,7 +26,7 @@
             this.labelSize = Game1.dialogueFont.MeasureString(this.label);
         }
 
-        public override void draw(SpriteBatch b, int slotX, int slotY)
+        public override void draw(SpriteBatch b, int slotX, int slotY, IClickableMenu context = null)
         {
             this.isChecked = this.objectList.OverlayActive;
             base.draw(b, slotX, slotY);

--- a/DynamicChecklist/Options/DCOptionsDropdown.cs
+++ b/DynamicChecklist/Options/DCOptionsDropdown.cs
@@ -99,7 +99,7 @@
             this.held = false;
         }
 
-        public override void draw(SpriteBatch b, int slotX, int slotY)
+        public override void draw(SpriteBatch b, int slotX, int slotY, IClickableMenu context = null)
         {
             this.recentSlotY = slotY;
             base.draw(b, slotX, slotY);

--- a/DynamicChecklist/Options/DCOptionsInputListener.cs
+++ b/DynamicChecklist/Options/DCOptionsInputListener.cs
@@ -93,7 +93,7 @@
             }
         }
 
-        public override void draw(SpriteBatch b, int slotX, int slotY)
+        public override void draw(SpriteBatch b, int slotX, int slotY, IClickableMenu context = null)
         {
             if (this.buttonNames.Count > 0 || this.whichOption == -1)
             {


### PR DESCRIPTION
The draw method changed for OptionsElement, this patch will
add the missing IClickableMenu context argument (defaults to null).

I've tested this on Stardew Valley 1.5.4 (latest Steam release)